### PR TITLE
Namespace Re-organize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,5 @@ install:
 
 script:
   - php artisan route:cache
-  - ./vendor/bin/phpunit
+  - ./vendor/bin/phpunit -v
   - php artisan migrate:rollback

--- a/app/functions.php
+++ b/app/functions.php
@@ -1,9 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Guardian\Models\Config;
-
 if (!function_exists('apcu_fetch') && function_exists('apc_fetch')) {
     function apcu_fetch($key, &$success) {
         return apc_fetch($key, $success);
@@ -13,46 +9,5 @@ if (!function_exists('apcu_fetch') && function_exists('apc_fetch')) {
 if (!function_exists('apcu_store') && function_exists('apc_store')) {
     function apcu_store() {
         return call_user_func_array('apc_store', func_get_args());
-    }
-}
-
-
-if (!function_exists('preference')) {
-
-    /**
-     * @param string $name
-     * @param mixed $fallback
-     *
-     * @return mixed|null
-     */
-    function preference($name, $fallback = null)
-    {
-        $value = env($name);
-        if ($value !== null) {
-            return $value;
-        }
-
-        $value = config($name);
-        if ($value !== null) {
-            return $value;
-        }
-
-        // Try to load from cache
-        $value = Cache::get("config:{$name}");
-        if ($value !== null) {
-            return $value;
-        }
-
-        try {
-            $modal = Config::findOrFail($name);
-            $value = $modal->value;
-            Cache::forever("config:{$name}", $value);
-        } catch (ModelNotFoundException $e) {
-            Cache::forever("config:{$name}", $fallback);
-
-            return $fallback;
-        }
-
-        return $value;
     }
 }

--- a/app/functions.php
+++ b/app/functions.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use App\Models\Config;
+use Guardian\Models\Config;
 
 if (!function_exists('apcu_fetch') && function_exists('apc_fetch')) {
     function apcu_fetch($key, &$success) {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
       "database"
     ],
     "psr-4": {
-      "App\\": "app/"
+      "App\\": "app/",
+      "Guardian\\": "lib/"
     },
     "files": [
       "app/functions.php"

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Guardian;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Guardian\Models\Config;
+
+
+class Core {
+
+    /**
+     * @param string $name
+     * @param mixed $fallback
+     *
+     * @return mixed|null
+     */
+    public static function preference($name, $fallback = null)
+    {
+        $value = env($name);
+        if ($value !== null) {
+            return $value;
+        }
+
+        $value = config($name);
+        if ($value !== null) {
+            return $value;
+        }
+
+        // Try to load from cache
+        $value = Cache::get("config:{$name}");
+        if ($value !== null) {
+            return $value;
+        }
+
+        try {
+            $modal = Config::findOrFail($name);
+            $value = $modal->value;
+            Cache::forever("config:{$name}", $value);
+        } catch (ModelNotFoundException $e) {
+            Cache::forever("config:{$name}", $fallback);
+
+            return $fallback;
+        }
+
+        return $value;
+    }
+}

--- a/lib/Models/Biblio.php
+++ b/lib/Models/Biblio.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Guardian\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/lib/Models/Branch.php
+++ b/lib/Models/Branch.php
@@ -31,7 +31,7 @@
  * @license  http://opensource.org/licenses/MIT MIT License
  */
 
-namespace App\Models;
+namespace Guardian\Models;
 
 class Branch extends Model
 {

--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Guardian\Models;
 
 class Config extends Model
 {

--- a/lib/Models/Item.php
+++ b/lib/Models/Item.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Guardian\Models;
 
 class Item extends Model
 {

--- a/lib/Models/Location.php
+++ b/lib/Models/Location.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Guardian\Models;
 
 class Location extends Model
 {

--- a/lib/Models/Model.php
+++ b/lib/Models/Model.php
@@ -31,7 +31,7 @@
  * @license  http://opensource.org/licenses/MIT MIT License
  */
 
-namespace App\Models;
+namespace Guardian\Models;
 
 use Illuminate\Database\Eloquent\Model as BaseModel;
 

--- a/lib/Models/Patron.php
+++ b/lib/Models/Patron.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Guardian\Models;
 
 class Patron extends Model
 {

--- a/lib/Models/User.php
+++ b/lib/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Guardian\Models;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;

--- a/tests/CoreTest.php
+++ b/tests/CoreTest.php
@@ -35,17 +35,17 @@ namespace App\Tests;
 
 use Illuminate\Support\Facades\Cache;
 use Guardian\Models\Config;
+use Guardian\Core;
 
-class FunctionsTest extends \TestCase
+class CoreTest extends \TestCase
 {
     public function testPreference()
     {
-        $this->assertTrue(function_exists('preference'));
-        $this->assertEquals(preference('APP_ENV'), env('APP_ENV'));
+        $this->assertEquals(Core::preference('APP_ENV'), env('APP_ENV'));
 
         $name = "hello_" . bin2hex(random_bytes(10));
-        $this->assertEquals("not set", preference($name, "not set"));
-        //$this->assertEquals("not set", preference($name, "not set (again)"));
+        $this->assertEquals("not set", Core::preference($name, "not set"));
+        $this->assertEquals("not set", Core::preference($name, "not set (again)"));
 
         // need to remove cache to reset default
         Cache::forget("config:{$name}");
@@ -56,7 +56,7 @@ class FunctionsTest extends \TestCase
         $hello->name = $name;
         $hello->value = "world";
         $hello->save();
-        $this->assertEquals("world", preference($name, "not set"));
+        $this->assertEquals("world", Core::preference($name, "not set"));
 
         // need to remove cache to reset default
         Cache::forget("config:{$name}");
@@ -65,6 +65,6 @@ class FunctionsTest extends \TestCase
         // delete config
         $hello->delete();
 
-        $this->assertEquals(preference($name, "not set"), "not set");
+        $this->assertEquals(Core::preference($name, "not set"), "not set");
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -34,7 +34,7 @@
 namespace App\Tests;
 
 use Illuminate\Support\Facades\Cache;
-use App\Models\Config;
+use Guardian\Models\Config;
 
 class FunctionsTest extends \TestCase
 {


### PR DESCRIPTION
I want to propose a structure change to how the source code are organize.

This pull request implements the organizational change:

1. Move everything we write for Guardian into `app/Guardian` directory.
2. Use `Guardian` instead of `app\Guardian` namespace for PSR-4 autoload.
3. Add PSR-4 autoload config into composer.

If we're careful with our footprint, our software can be installed as part of a Laravel installation. And we might have flexibility to easily upgrade Laravel (or even be independent from it in the future).